### PR TITLE
Fix MD5 utils

### DIFF
--- a/src/main/java/com/site/blog/my/core/util/MD5Util.java
+++ b/src/main/java/com/site/blog/my/core/util/MD5Util.java
@@ -11,7 +11,7 @@ import java.security.MessageDigest;
 public class MD5Util {
 
     private static String byteArrayToHexString(byte b[]) {
-        StringBuffer resultSb = new StringBuffer();
+        StringBuilder resultSb = new StringBuilder();
         for (int i = 0; i < b.length; i++)
             resultSb.append(byteToHexString(b[i]));
 
@@ -39,6 +39,7 @@ public class MD5Util {
                 resultString = byteArrayToHexString(md.digest(resultString
                         .getBytes(charsetname)));
         } catch (Exception exception) {
+            exception.printStackTrace();
         }
         return resultString;
     }


### PR DESCRIPTION
## Summary
- replace `StringBuffer` with `StringBuilder`
- log the `Exception` in `MD5Encode`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_683eb94182a08324adbf7aefa911d25a