### PR TITLE
Refactor PatternUtil regex handling

### DIFF
--- a/src/main/java/com/site/blog/my/core/util/PatternUtil.java
+++ b/src/main/java/com/site/blog/my/core/util/PatternUtil.java
@@ -20,16 +20,25 @@ public class PatternUtil {
             Pattern.compile("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,6}$", Pattern.CASE_INSENSITIVE);
 
     /**
+     * 匹配仅由中英文和数字组成的关键字
+     */
+    private static final Pattern KEYWORD_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9\\u4E00-\\u9FA5]+$");
+
+    /**
+     * 匹配URL
+     */
+    private static final Pattern URL_PATTERN = Pattern.compile(
+            "^([hH][tT]{2}[pP]:/*|[hH][tT]{2}[pP][sS]:/*|[fF][tT][pP]:/*)(([A-Za-z0-9-~]+).)+([A-Za-z0-9-~\\/])+(\\?{0,1}(([A-Za-z0-9-~]+\\={0,1})([A-Za-z0-9-~]*)\\&{0,1})*)$");
+
+    /**
      * 验证只包含中英文和数字的字符串
      *
      * @param keyword
      * @return
      */
     public static Boolean validKeyword(String keyword) {
-        String regex = "^[a-zA-Z0-9\u4E00-\u9FA5]+$";
-        Pattern pattern = Pattern.compile(regex);
-        Matcher match = pattern.matcher(keyword);
-        return match.matches();
+        return KEYWORD_PATTERN.matcher(keyword).matches();
     }
 
 
@@ -51,13 +60,7 @@ public class PatternUtil {
      * @return
      */
     public static boolean isURL(String urlString) {
-        String regex = "^([hH][tT]{2}[pP]:/*|[hH][tT]{2}[pP][sS]:/*|[fF][tT][pP]:/*)(([A-Za-z0-9-~]+).)+([A-Za-z0-9-~\\/])+(\\?{0,1}(([A-Za-z0-9-~]+\\={0,1})([A-Za-z0-9-~]*)\\&{0,1})*)$";
-        Pattern pattern = Pattern.compile(regex);
-        if (pattern.matcher(urlString).matches()) {
-            return true;
-        } else {
-            return false;
-        }
+        return URL_PATTERN.matcher(urlString).matches();
     }
 
 }


### PR DESCRIPTION
## Summary
- centralize keyword and URL regex patterns
- simplify `validKeyword` and `isURL` by using the static patterns directly

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683fb9628c1c8324a47a9b4e16672f57