### PR TITLE
Use generic Result in generator

### DIFF
--- a/src/main/java/com/site/blog/my/core/util/ResultGenerator.java
+++ b/src/main/java/com/site/blog/my/core/util/ResultGenerator.java
@@ -16,30 +16,30 @@ public class ResultGenerator {
     private static final int RESULT_CODE_SUCCESS = 200;
     private static final int RESULT_CODE_SERVER_ERROR = 500;
 
-    public static Result genSuccessResult() {
-        Result result = new Result();
+    public static <T> Result<T> genSuccessResult() {
+        Result<T> result = new Result<>();
         result.setResultCode(RESULT_CODE_SUCCESS);
         result.setMessage(DEFAULT_SUCCESS_MESSAGE);
         return result;
     }
 
-    public static Result genSuccessResult(String message) {
-        Result result = new Result();
+    public static <T> Result<T> genSuccessResult(String message) {
+        Result<T> result = new Result<>();
         result.setResultCode(RESULT_CODE_SUCCESS);
         result.setMessage(message);
         return result;
     }
 
-    public static Result genSuccessResult(Object data) {
-        Result result = new Result();
+    public static <T> Result<T> genSuccessResult(T data) {
+        Result<T> result = new Result<>();
         result.setResultCode(RESULT_CODE_SUCCESS);
         result.setMessage(DEFAULT_SUCCESS_MESSAGE);
         result.setData(data);
         return result;
     }
 
-    public static Result genFailResult(String message) {
-        Result result = new Result();
+    public static <T> Result<T> genFailResult(String message) {
+        Result<T> result = new Result<>();
         result.setResultCode(RESULT_CODE_SERVER_ERROR);
         if (!StringUtils.hasText(message)) {
             result.setMessage(DEFAULT_FAIL_MESSAGE);
@@ -49,8 +49,8 @@ public class ResultGenerator {
         return result;
     }
 
-    public static Result genErrorResult(int code, String message) {
-        Result result = new Result();
+    public static <T> Result<T> genErrorResult(int code, String message) {
+        Result<T> result = new Result<>();
         result.setResultCode(code);
         result.setMessage(message);
         return result;


### PR DESCRIPTION
## Summary
- refactor `ResultGenerator` to return `Result<T>`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683fbdd3e9888324b43c4b1aa7f3d00a