### PR TITLE
Improve upload controllers

### DIFF
--- a/src/main/java/com/site/blog/my/core/controller/admin/BlogController.java
+++ b/src/main/java/com/site/blog/my/core/controller/admin/BlogController.java
@@ -8,6 +8,8 @@ import com.site.blog.my.core.util.MyBlogUtils;
 import com.site.blog.my.core.util.PageQueryUtil;
 import com.site.blog.my.core.util.Result;
 import com.site.blog.my.core.util.ResultGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -36,6 +38,8 @@ import java.util.Random;
 @Controller
 @RequestMapping("/admin")
 public class BlogController {
+
+    private static final Logger logger = LoggerFactory.getLogger(BlogController.class);
 
     @Resource
     private BlogService blogService;
@@ -201,7 +205,7 @@ public class BlogController {
         File fileDirectory = new File(Constants.FILE_UPLOAD_DIC);
         try {
             if (!fileDirectory.exists()) {
-                if (!fileDirectory.mkdir()) {
+                if (!fileDirectory.mkdirs()) {
                     throw new IOException("文件夹创建失败,路径为：" + fileDirectory);
                 }
             }
@@ -209,9 +213,8 @@ public class BlogController {
             request.setCharacterEncoding("utf-8");
             response.setHeader("Content-Type", "text/html");
             response.getWriter().write("{\"success\": 1, \"message\":\"success\",\"url\":\"" + fileUrl + "\"}");
-        } catch (UnsupportedEncodingException e) {
-            response.getWriter().write("{\"success\":0}");
-        } catch (IOException e) {
+        } catch (Exception e) {
+            logger.error("Markdown文件上传失败", e);
             response.getWriter().write("{\"success\":0}");
         }
     }

--- a/src/main/java/com/site/blog/my/core/controller/admin/UploadController.java
+++ b/src/main/java/com/site/blog/my/core/controller/admin/UploadController.java
@@ -4,6 +4,8 @@ import com.site.blog.my.core.config.Constants;
 import com.site.blog.my.core.util.MyBlogUtils;
 import com.site.blog.my.core.util.Result;
 import com.site.blog.my.core.util.ResultGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +34,8 @@ import java.util.UUID;
 @RequestMapping("/admin")
 public class UploadController {
 
+    private static final Logger logger = LoggerFactory.getLogger(UploadController.class);
+
     @PostMapping({"/upload/file"})
     @ResponseBody
     public Result upload(HttpServletRequest httpServletRequest, @RequestParam("file") MultipartFile file) throws URISyntaxException {
@@ -48,7 +52,7 @@ public class UploadController {
         File destFile = new File(Constants.FILE_UPLOAD_DIC + newFileName);
         try {
             if (!fileDirectory.exists()) {
-                if (!fileDirectory.mkdir()) {
+                if (!fileDirectory.mkdirs()) {
                     throw new IOException("文件夹创建失败,路径为：" + fileDirectory);
                 }
             }
@@ -57,7 +61,7 @@ public class UploadController {
             resultSuccess.setData(MyBlogUtils.getHost(new URI(httpServletRequest.getRequestURL() + "")) + "/upload/" + newFileName);
             return resultSuccess;
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("文件上传失败", e);
             return ResultGenerator.genFailResult("文件上传失败");
         }
     }


### PR DESCRIPTION
## Summary
- create directories recursively in UploadController and BlogController
- use slf4j Logger for error handling
- give consistent error response when uploads fail

## Testing
- `mvn -q test` *(fails: command not found)*
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842bebf25208324ac01ca04bf631433