### PR TITLE
Fix email validation

### DIFF
--- a/src/main/java/com/site/blog/my/core/util/PatternUtil.java
+++ b/src/main/java/com/site/blog/my/core/util/PatternUtil.java
@@ -50,7 +50,7 @@ public class PatternUtil {
      */
     public static boolean isEmail(String emailStr) {
         Matcher matcher = VALID_EMAIL_ADDRESS_REGEX.matcher(emailStr);
-        return matcher.find();
+        return matcher.matches();
     }
 
     /**


### PR DESCRIPTION
## Summary
- validate emails with `matches` instead of `find`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842c08d725083248b157d7fe574b831