### PR TITLE
Improve getHost exception handling

### DIFF
--- a/src/main/java/com/site/blog/my/core/util/MyBlogUtils.java
+++ b/src/main/java/com/site/blog/my/core/util/MyBlogUtils.java
@@ -1,19 +1,25 @@
 package com.site.blog.my.core.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * @author 13
  */
 public class MyBlogUtils {
 
+    private static final Logger logger = LoggerFactory.getLogger(MyBlogUtils.class);
+
     public static URI getHost(URI uri) {
         URI effectiveURI = null;
         try {
             effectiveURI = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null);
-        } catch (Throwable var4) {
+        } catch (URISyntaxException e) {
+            logger.error("Failed to parse host URI", e);
             effectiveURI = null;
         }
         return effectiveURI;


### PR DESCRIPTION
## Summary
- restrict exception handling to `URISyntaxException` in `MyBlogUtils.getHost`
- add SLF4J logger to log URI parsing failures

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842c41a00ac83249e7a9248c914f2c5